### PR TITLE
refactor(manguito-theme): refactor: tab-container, tab-content

### DIFF
--- a/src/components/manguito-theme/lib/tabs/InjectionKey.ts
+++ b/src/components/manguito-theme/lib/tabs/InjectionKey.ts
@@ -1,5 +1,12 @@
 import type { InjectionKey, Ref } from 'vue'
 
+/**
+ * @summary typedef TabInjectionType, which is used as of injection key controls activeIdx, containerHeight, and updateHeight functionality
+ * @arg {Ref<number>} activeTabIdx - current index of active tab
+ * @arg {Ref<number>} containerHeight - height of current tabContent (=activeIdx)
+ * @arg {(arg: number) => void} updateHeight - method to update value of containerHeight
+ */
+
 export interface TabInjectionType {
   activeTabIdx: Ref<number>
   containerHeight: Ref<number>

--- a/src/components/manguito-theme/lib/tabs/TabContainer.vue
+++ b/src/components/manguito-theme/lib/tabs/TabContainer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, provide, ref } from 'vue'
+import { computed, provide, ref, Transition, watch } from 'vue'
 import { tabInjectionKey } from './InjectionKey'
 
 withDefaults(
@@ -22,10 +22,15 @@ const slots = defineSlots<{
 
 const activeTabIdx = ref<number>(0)
 const containerHts = ref<number>(0)
+const slideDirection = ref<'slide-next' | 'slide-prev'>('slide-next')
 
 const updateHeight = (height: number) => {
   containerHts.value = height
 }
+
+/**
+ * @summary init injection key, shared with TabContent component
+ */
 provide(tabInjectionKey, {
   activeTabIdx,
   containerHeight: containerHts,
@@ -36,14 +41,34 @@ const updateActiveTab = (num: number) => {
   activeTabIdx.value = num
 }
 
+/**
+ * @summary fetch containerHts value updated from child component and update var(--container-hts) accordingly
+ */
+
 const containerHeightVar = computed(() => {
   return { '--container-hts': `${containerHts.value}px` }
 })
+
 defineExpose<{
   update: (arg: number) => void
 }>({
   update: updateActiveTab,
 })
+
+/**
+ * @summary watch value of activeIdx and determine the direction of slide animation
+ */
+
+watch(
+  () => activeTabIdx!.value,
+  (newValue, oldValue) => {
+    if (newValue > oldValue) {
+      slideDirection.value = 'slide-next'
+    } else {
+      slideDirection.value = 'slide-prev'
+    }
+  }
+)
 </script>
 
 <template>
@@ -56,15 +81,53 @@ defineExpose<{
       ></slot>
     </div>
     <div :class="contentContainerClass">
-      <div class="relative container-hts transition-[min-height] duration-300">
-        <slot name="tab-content"></slot>
+      <div
+        class="container-hts transition-[max-height] duration-300 grid grid-cols-1 grid-rows-1"
+      >
+        <Transition :name="slideDirection">
+          <div
+            :key="activeTabIdx"
+            class="col-start-1 col-end-1 row-start-1 row-end-1 relative"
+          >
+            <slot name="tab-content"></slot>
+          </div>
+        </Transition>
       </div>
     </div>
   </div>
 </template>
 
-<style scoped>
+<style scoped lang="scss">
 .container-hts {
-  min-height: var(--container-hts);
+  max-height: var(--container-hts);
+}
+/* transition animations */
+.slide-prev-enter-active {
+  transition: all 0.5s linear;
+}
+.slide-prev-leave-active {
+  transition: all 0.5s;
+}
+.slide-prev-enter-from {
+  transform: translateX(-100%);
+  opacity: 0;
+}
+.slide-prev-leave-to {
+  transform: translateX(100%);
+  opacity: 0;
+}
+.slide-next-enter-active {
+  transition: all 0.5s linear;
+}
+.slide-next-leave-active {
+  transition: all 0.5s;
+}
+.slide-next-enter-from {
+  transform: translateX(100%);
+  opacity: 0;
+}
+.slide-next-leave-to {
+  transform: translateX(-100%);
+  opacity: 0;
 }
 </style>

--- a/src/components/manguito-theme/lib/tabs/TabContent.vue
+++ b/src/components/manguito-theme/lib/tabs/TabContent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, inject, ref, Transition, watch } from 'vue'
+import { computed, inject, ref } from 'vue'
 import { tabInjectionKey, type TabInjectionType } from './InjectionKey'
 import { useElementSize } from '@vueuse/core'
 
@@ -17,7 +17,6 @@ const props = withDefaults(
 const { activeTabIdx, updateHeight } = inject(
   tabInjectionKey
 ) as TabInjectionType
-const slideDirection = ref<'slide-next' | 'slide-prev'>('slide-next')
 const slotRef = ref<HTMLElement | null>(null)
 
 const { height } = useElementSize(slotRef)
@@ -29,65 +28,18 @@ const isActive = computed<boolean>(() => {
   }
   return false
 })
-
-watch(
-  () => activeTabIdx!.value,
-  (newValue, oldValue) => {
-    if (newValue > oldValue) {
-      slideDirection.value = 'slide-next'
-    } else {
-      slideDirection.value = 'slide-prev'
-    }
-  }
-)
 </script>
 
 <template>
-  <Transition :name="slideDirection" mode="out-in">
-    <div
-      ref="slotRef"
-      :id="id"
-      :class="tabClass"
-      class="absolute w-full"
-      role="tabpanel"
-      tabindex="-1"
-      v-show="isActive"
-    >
-      <div class="relative">
-        <slot></slot>
-      </div>
-    </div>
-  </Transition>
+  <div
+    ref="slotRef"
+    :id="id"
+    :class="tabClass"
+    class="w-full"
+    role="tabpanel"
+    tabindex="-1"
+    v-show="isActive"
+  >
+    <slot></slot>
+  </div>
 </template>
-
-<style scoped>
-/* transition animations */
-.slide-prev-enter-active {
-  transition: all 0.5s linear;
-}
-.slide-prev-leave-active {
-  transition: all 0.5s;
-}
-.slide-prev-enter-from {
-  transform: translateX(-100%);
-  opacity: 0;
-}
-.slide-prev-leave-to {
-  transform: translateX(100%);
-  opacity: 0;
-}
-.slide-next-enter-active {
-  transition: all 0.5s linear;
-}
-.slide-next-leave-active {
-  transition: all 0.5s;
-}
-.slide-next-enter-from {
-  transform: translateX(100%);
-  opacity: 0;
-}
-.slide-next-leave-to {
-  transform: translateX(-100%);
-  opacity: 0;
-}
-</style>


### PR DESCRIPTION
refactor the tab components by moving transition tag in tab-content to the tab-container component. remove absolute positioning of tab-content, switch container height animation to be triggered by using max-height instead of min-height.

mcl-41