### PR TITLE
feat(*): apply phase 4 accessibility fixes

### DIFF
--- a/docs/mcl-82/decisions/phase-04-accessibility.md
+++ b/docs/mcl-82/decisions/phase-04-accessibility.md
@@ -1,0 +1,119 @@
+# Phase 4 — Accessibility Decisions
+
+This document records the architectural decisions made before implementing the Phase 4 accessibility fixes. It is the authoritative reference for implementation choices in `mcl-82/phase-04-accessibility`.
+
+---
+
+## New Dependencies
+
+All three are added to `manguito-theme`'s `dependencies` (not devDependencies — they ship with the package).
+
+| Package | Purpose |
+|---|---|
+| `@vueuse/integrations` | Provides `useFocusTrap` composable (SSR-safe wrapper) |
+| `focus-trap` | Required peer dep of `@vueuse/integrations`; the underlying trap engine |
+| `isomorphic-dompurify` | HTML sanitization for `v-html` / `innerHTML` usage; SSR-safe |
+
+**Why `@vueuse/integrations` over a custom focus trap?**
+VueUse composables are SSR-safe by design and integrate naturally with Vue 3's lifecycle. Writing a custom focus trap duplicates well-tested work. `focus-trap` must be installed alongside `@vueuse/integrations` because it is a required peer dependency, not optional.
+
+---
+
+## 4a — Modal & Sidebar
+
+### ARIA attributes
+- Add `role="dialog"` and `aria-modal="true"` to the dialog container.
+- Wire `aria-labelledby` to the component's existing `id` prop (both Modal and Sidebar already expose an `id`).
+
+### Focus trap
+- Use `useFocusTrap` from `@vueuse/integrations`.
+- Activate on open, deactivate on close, tied to the existing `toggle` / `visible` reactive state.
+
+### Focus return
+- Store `document.activeElement` at the moment the dialog opens (inside the open handler / `watch` — client-side only via lifecycle, no SSR guard needed beyond that).
+- Restore it on close via `.focus()`.
+
+### Close button accessible label
+- Add `aria-label="Close"` to the close button SVGs.
+- Sidebar renders two close button blocks (one per `placement`); both receive the label.
+
+---
+
+## 4b — Collapse triggers
+
+### Trigger element
+- Change `<div v-collapse>` to `<button type="button">` in `MclCollapseA` and `MclCollapseB`.
+- Reset any default button browser styling via existing utility classes.
+
+### `aria-expanded`
+- Introduce a local `isOpen` ref in each component to drive `aria-expanded`.
+- The click handler updates `isOpen` alongside the existing `v-collapse` call.
+- **Known Phase 4 limitation**: when an accordion sibling closes this component externally (via `vCollapse` DOM manipulation), the local `isOpen` ref will not update, leaving `aria-expanded` stale. This is resolved in Phase 5 when `vCollapse` is replaced with a `provide`/`inject` composable.
+
+### `aria-controls` and region role
+- Add `aria-controls` on the trigger pointing to the existing `:id="collapseId"` on the collapse region.
+- Add `role="region"` and `aria-labelledby` on the collapse region pointing back to the trigger button's `id`.
+
+### `NavCollapse` in `mcl-header`
+- Already uses `<button>` — only needs `aria-expanded` and `aria-controls` added.
+
+---
+
+## 4c — Form validation announcements
+
+### `aria-invalid` mechanism
+- Add a new **`:invalid` boolean prop** (default `false`) to `MclInputText`, `MclTextArea`, and `MclSelect`.
+- Bind `aria-invalid="true"` when the prop is true.
+- **Why a prop, not `ValidityState` check?** A component library must be framework-agnostic. Consumers may use Vuelidate, VeeValidate, native constraint validation, or nothing. A prop makes the state explicit and SSR-safe (no browser API calls at render time).
+
+### Error announcement
+- Add `role="alert"` to the `invalidFeedback` error container in `MclInputText`, `MclTextArea`, and `MclSelect` so errors are announced by screen readers when they appear.
+
+### `MclInputFile`
+- Associate the browse button with the file input via `aria-controls` pointing to the input's `id`, or restructure with a `<label>` wrapping the hidden input.
+
+### `MclCheckbox`, `MclInputSwitch`, `MclInputRadio`
+- These use `appearance-none` hidden native inputs with visual `<span>` elements.
+- The native `<input>` must remain focusable and reachable by keyboard — verify `appearance-none` does not suppress focus on the actual input.
+- `MclInputSwitch`: add `role="switch"` and `aria-checked` to the visual element if the input is not directly keyboard-reachable; otherwise the native `<input type="checkbox">` semantics are sufficient.
+- `MclInputRadio`: same pattern — native `<input type="radio">` semantics are preferred over custom ARIA if the input is keyboard-reachable.
+
+---
+
+## 4d — MclSelect ARIA combobox completion
+
+The component already has `role="combobox"`, `aria-autocomplete`, `aria-expanded`, `role="listbox"`, and `role="option"`. The missing wiring:
+
+- Add a stable `id` to the listbox `<ul>`.
+- Add `aria-controls` on the combobox `<input>` pointing to that `id`.
+- Set `aria-activedescendant` on the input to the `id` of the currently highlighted `<li>`.
+- Each `<li>` option needs a unique `id` (e.g., `${componentId}-option-${index}`) and `aria-selected` bound to whether it is the selected value.
+
+---
+
+## 4e — Tooltip
+
+### Unique ID
+- Use `useId()` from Vue 3.5 (available — project targets `^3.5.13`).
+- Assign the generated id to the tooltip element.
+
+### `aria-describedby`
+- Set `aria-describedby` on the host element pointing to the tooltip's `id`.
+- Applied in the directive (`tooltip.directive.ts`) where the host element is available.
+
+### Keyboard trigger
+- Add `focus` and `blur` event listeners on the host element alongside the existing CSS `group-hover`.
+- Show tooltip on focus, hide on blur.
+
+### HTML sanitization
+- Replace `innerHTML` injection of `props.title` with `isomorphic-dompurify`'s `sanitize()`.
+- `isomorphic-dompurify` returns an empty string on the server (no DOM available), which is safe.
+- This protects all `v-html` / `innerHTML` usage in the tooltip; the broader `v-html` audit across other components is deferred to Phase 6.
+
+---
+
+## Known Limitations (accepted for Phase 4)
+
+| Limitation | Resolution |
+|---|---|
+| `aria-expanded` on accordion-sibling-closed collapses will be stale | Phase 5 replaces `vCollapse` with `provide`/`inject`; state will be reactive at that point |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,7 +178,7 @@ importers:
         version: 4.5.4(@types/node@22.10.1)(rollup@4.57.0)(typescript@5.9.3)(vite@7.3.1(@types/node@22.10.1)(jiti@2.4.2)(lightningcss@1.30.1)(sass@1.97.3)(yaml@2.7.1))
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@22.10.1)(@vitest/coverage-v8@4.1.6)(happy-dom@20.9.0)(vite@7.3.1(@types/node@22.10.1)(jiti@2.4.2)(lightningcss@1.30.1)(sass@1.97.3)(yaml@2.7.1))
+        version: 4.1.6(@types/node@22.10.1)(@vitest/coverage-v8@4.1.6)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.1(@types/node@22.10.1)(jiti@2.4.2)(lightningcss@1.30.1)(sass@1.97.3)(yaml@2.7.1))
       vue-tsc:
         specifier: 3.2.4
         version: 3.2.4(typescript@5.9.3)
@@ -188,6 +188,15 @@ importers:
       '@vueuse/core':
         specifier: 14.1.0
         version: 14.1.0(vue@3.5.27(typescript@5.9.3))
+      '@vueuse/integrations':
+        specifier: ^14.3.0
+        version: 14.3.0(axios@1.9.0)(focus-trap@8.2.0)(vue@3.5.27(typescript@5.9.3))
+      focus-trap:
+        specifier: ^8.2.0
+        version: 8.2.0
+      isomorphic-dompurify:
+        specifier: ^3.12.0
+        version: 3.12.0
       vue:
         specifier: ^3.5.27
         version: 3.5.27(typescript@5.9.3)
@@ -546,6 +555,21 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
@@ -597,6 +621,10 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@chromatic-com/storybook@3.2.2':
     resolution: {integrity: sha512-xmXt/GW0hAPbzNTrxYuVo43Adrtjue4DeVrsoIIEeJdGaPNNeNf+DHMlJKOBdlHmCnFUoe9R/0mLM9zUp5bKWw==}
     engines: {node: '>=16.0.0', yarn: '>=1.22.18'}
@@ -626,6 +654,42 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.0':
+    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@emnapi/core@1.4.3':
     resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
@@ -941,6 +1005,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.4':
     resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
@@ -2009,6 +2082,9 @@ packages:
   '@types/through@0.0.33':
     resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -2197,11 +2273,58 @@ packages:
     peerDependencies:
       vue: ^3.5.27
 
+  '@vueuse/integrations@14.3.0':
+    resolution: {integrity: sha512-76I5FT2ESvCmCaSwapI+a/u/CFtNXmzl9f9lNp1hRtx8vKB8hfiokJr8IvQqcQG5ckGXElyXK516b54ozV3MvA==}
+    peerDependencies:
+      async-validator: ^4
+      axios: ^1
+      change-case: ^5
+      drauu: ^0.4
+      focus-trap: ^7 || ^8
+      fuse.js: ^7
+      idb-keyval: ^6
+      jwt-decode: ^4
+      nprogress: ^0.2
+      qrcode: ^1.5
+      sortablejs: ^1
+      universal-cookie: ^7 || ^8
+      vue: ^3.5.27
+    peerDependenciesMeta:
+      async-validator:
+        optional: true
+      axios:
+        optional: true
+      change-case:
+        optional: true
+      drauu:
+        optional: true
+      focus-trap:
+        optional: true
+      fuse.js:
+        optional: true
+      idb-keyval:
+        optional: true
+      jwt-decode:
+        optional: true
+      nprogress:
+        optional: true
+      qrcode:
+        optional: true
+      sortablejs:
+        optional: true
+      universal-cookie:
+        optional: true
+
   '@vueuse/metadata@14.1.0':
     resolution: {integrity: sha512-7hK4g015rWn2PhKcZ99NyT+ZD9sbwm7SGvp7k+k+rKGWnLjS/oQozoIZzWfCewSUeBmnJkIb+CNr7Zc/EyRnnA==}
 
   '@vueuse/shared@14.1.0':
     resolution: {integrity: sha512-EcKxtYvn6gx1F8z9J5/rsg3+lTQnvOruQd8fUecW99DCK04BkWD7z5KQ/wTAx+DazyoEE9dJt/zV8OIEQbM6kw==}
+    peerDependencies:
+      vue: ^3.5.27
+
+  '@vueuse/shared@14.3.0':
+    resolution: {integrity: sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==}
     peerDependencies:
       vue: ^3.5.27
 
@@ -2410,6 +2533,9 @@ packages:
   better-opn@3.0.2:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
     engines: {node: '>=12.0.0'}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   bin-links@4.0.4:
     resolution: {integrity: sha512-cMtq4W5ZsEwcutJrVId+a/tjt8GSbS+h0oNkdl6+6rBuEv8Ot33Bevj5KPm40t309zuhVic8NjpuL42QCiJWWA==}
@@ -2794,6 +2920,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
@@ -2812,6 +2942,10 @@ packages:
   dargs@7.0.0:
     resolution: {integrity: sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==}
     engines: {node: '>=8'}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   dateformat@3.0.3:
     resolution: {integrity: sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==}
@@ -2835,6 +2969,9 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.1.0:
     resolution: {integrity: sha512-Wy+JTSbFThEOXQIR2L6mxJvEs+veIzpmqD7ynWxMXGpnk3smkHQOp6forLdHsKpAMW9iJpaBBIxz285t1n1C3w==}
@@ -2925,6 +3062,9 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dompurify@3.4.2:
+    resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
+
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
@@ -2991,6 +3131,10 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -3164,6 +3308,9 @@ packages:
   flat@5.0.2:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
+
+  focus-trap@8.2.0:
+    resolution: {integrity: sha512-CaBdQ9P4fa/yCA6pDf/3aJd8bf9IOG5QGK21/E+86o2V4V8kzXaR4A9E6tNR7KkkS1+T5ZIU1tJDBDLwsucz9g==}
 
   follow-redirects@1.15.9:
     resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
@@ -3391,6 +3538,10 @@ packages:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -3572,6 +3723,9 @@ packages:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@2.2.2:
     resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
 
@@ -3622,6 +3776,10 @@ packages:
   isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
+
+  isomorphic-dompurify@3.12.0:
+    resolution: {integrity: sha512-8n+j+6ypTHvriJwFOQ2qusQ6bzGjZVcR3jbe1pBpLcGI1dn4WIl0ctLBngqE5QttquQBAlKXwJeTMw+X7x7qKw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -3690,6 +3848,15 @@ packages:
   jsdoc-type-pratt-parser@4.1.0:
     resolution: {integrity: sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==}
     engines: {node: '>=12.0.0'}
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-parse-better-errors@1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
@@ -3895,6 +4062,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.3.6:
+    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
+    engines: {node: 20 || >=22}
+
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
@@ -3981,6 +4152,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   memoizerific@1.11.3:
     resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
@@ -4444,6 +4618,9 @@ packages:
   parse-url@8.1.0:
     resolution: {integrity: sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -4877,6 +5054,10 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
@@ -5082,6 +5263,12 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tabbable@6.4.0:
+    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+
   tailwindcss@4.1.18:
     resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
 
@@ -5145,6 +5332,13 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.30:
+    resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
+
+  tldts@7.0.30:
+    resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
+    hasBin: true
+
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
@@ -5160,8 +5354,16 @@ packages:
   token-stream@1.0.0:
     resolution: {integrity: sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==}
 
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   treeverse@3.0.0:
     resolution: {integrity: sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==}
@@ -5251,6 +5453,10 @@ packages:
 
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -5479,6 +5685,10 @@ packages:
       typescript:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   walk-up-path@3.0.1:
     resolution: {integrity: sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA==}
 
@@ -5488,12 +5698,24 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -5593,6 +5815,13 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -5651,6 +5880,26 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
@@ -5693,6 +5942,10 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
 
   '@chromatic-com/storybook@3.2.2(react@19.1.0)(storybook@8.6.12(prettier@3.8.1))':
     dependencies:
@@ -5752,6 +6005,30 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@emnapi/core@1.4.3':
     dependencies:
@@ -5918,6 +6195,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.2':
     optional: true
+
+  '@exodus/bytes@1.15.0': {}
 
   '@floating-ui/core@1.7.4':
     dependencies:
@@ -7112,6 +7391,9 @@ snapshots:
     dependencies:
       '@types/node': 22.10.1
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@3.0.3': {}
 
   '@types/uuid@9.0.8': {}
@@ -7141,7 +7423,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@22.10.1)(@vitest/coverage-v8@4.1.6)(happy-dom@20.9.0)(vite@7.3.1(@types/node@22.10.1)(jiti@2.4.2)(lightningcss@1.30.1)(sass@1.97.3)(yaml@2.7.1))
+      vitest: 4.1.6(@types/node@22.10.1)(@vitest/coverage-v8@4.1.6)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.1(@types/node@22.10.1)(jiti@2.4.2)(lightningcss@1.30.1)(sass@1.97.3)(yaml@2.7.1))
 
   '@vitest/expect@2.0.5':
     dependencies:
@@ -7388,9 +7670,22 @@ snapshots:
       '@vueuse/shared': 14.1.0(vue@3.5.27(typescript@5.9.3))
       vue: 3.5.27(typescript@5.9.3)
 
+  '@vueuse/integrations@14.3.0(axios@1.9.0)(focus-trap@8.2.0)(vue@3.5.27(typescript@5.9.3))':
+    dependencies:
+      '@vueuse/core': 14.1.0(vue@3.5.27(typescript@5.9.3))
+      '@vueuse/shared': 14.3.0(vue@3.5.27(typescript@5.9.3))
+      vue: 3.5.27(typescript@5.9.3)
+    optionalDependencies:
+      axios: 1.9.0
+      focus-trap: 8.2.0
+
   '@vueuse/metadata@14.1.0': {}
 
   '@vueuse/shared@14.1.0(vue@3.5.27(typescript@5.9.3))':
+    dependencies:
+      vue: 3.5.27(typescript@5.9.3)
+
+  '@vueuse/shared@14.3.0(vue@3.5.27(typescript@5.9.3))':
     dependencies:
       vue: 3.5.27(typescript@5.9.3)
 
@@ -7564,6 +7859,10 @@ snapshots:
   better-opn@3.0.2:
     dependencies:
       open: 8.4.2
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bin-links@4.0.4:
     dependencies:
@@ -8018,6 +8317,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   css.escape@1.5.1: {}
 
   cssesc@3.0.0: {}
@@ -8040,6 +8344,13 @@ snapshots:
 
   dargs@7.0.0: {}
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   dateformat@3.0.3: {}
 
   de-indent@1.0.2: {}
@@ -8054,6 +8365,8 @@ snapshots:
       map-obj: 1.0.1
 
   decamelize@1.2.0: {}
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.1.0:
     dependencies:
@@ -8113,6 +8426,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.4.2:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dot-prop@5.3.0:
     dependencies:
@@ -8177,6 +8494,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@7.0.1: {}
+
+  entities@8.0.0: {}
 
   env-paths@2.2.1: {}
 
@@ -8387,6 +8706,10 @@ snapshots:
       resolve-dir: 1.0.1
 
   flat@5.0.2: {}
+
+  focus-trap@8.2.0:
+    dependencies:
+      tabbable: 6.4.0
 
   follow-redirects@1.15.9: {}
 
@@ -8641,6 +8964,12 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@2.0.2: {}
 
   http-cache-semantics@4.1.1: {}
@@ -8837,6 +9166,8 @@ snapshots:
     dependencies:
       isobject: 3.0.1
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@2.2.2: {}
 
   is-regex@1.2.1:
@@ -8877,6 +9208,14 @@ snapshots:
   isexe@3.1.1: {}
 
   isobject@3.0.1: {}
+
+  isomorphic-dompurify@3.12.0:
+    dependencies:
+      dompurify: 3.4.2
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - canvas
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -8945,6 +9284,32 @@ snapshots:
   jsbn@1.1.0: {}
 
   jsdoc-type-pratt-parser@4.1.0: {}
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.6
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   json-parse-better-errors@1.0.2: {}
 
@@ -9212,6 +9577,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.3.6: {}
+
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
@@ -9373,6 +9740,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
 
   memoizerific@1.11.3:
     dependencies:
@@ -10024,6 +10393,10 @@ snapshots:
     dependencies:
       parse-path: 7.1.0
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-browserify@1.0.1: {}
 
   path-exists@3.0.0: {}
@@ -10435,6 +10808,10 @@ snapshots:
     optionalDependencies:
       '@parcel/watcher': 2.5.1
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.26.0: {}
 
   semver@5.7.2: {}
@@ -10641,6 +11018,10 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
+  tabbable@6.4.0: {}
+
   tailwindcss@4.1.18: {}
 
   tapable@2.2.2: {}
@@ -10703,6 +11084,12 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  tldts-core@7.0.30: {}
+
+  tldts@7.0.30:
+    dependencies:
+      tldts-core: 7.0.30
+
   tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
@@ -10715,7 +11102,15 @@ snapshots:
 
   token-stream@1.0.0: {}
 
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.30
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   treeverse@3.0.0: {}
 
@@ -10785,6 +11180,8 @@ snapshots:
     optional: true
 
   undici-types@6.20.0: {}
+
+  undici@7.25.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -10910,7 +11307,7 @@ snapshots:
       sass: 1.97.3
       yaml: 2.7.1
 
-  vitest@4.1.6(@types/node@22.10.1)(@vitest/coverage-v8@4.1.6)(happy-dom@20.9.0)(vite@7.3.1(@types/node@22.10.1)(jiti@2.4.2)(lightningcss@1.30.1)(sass@1.97.3)(yaml@2.7.1)):
+  vitest@4.1.6(@types/node@22.10.1)(@vitest/coverage-v8@4.1.6)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.1(@types/node@22.10.1)(jiti@2.4.2)(lightningcss@1.30.1)(sass@1.97.3)(yaml@2.7.1)):
     dependencies:
       '@vitest/expect': 4.1.6
       '@vitest/mocker': 4.1.6(vite@7.3.1(@types/node@22.10.1)(jiti@2.4.2)(lightningcss@1.30.1)(sass@1.97.3)(yaml@2.7.1))
@@ -10936,6 +11333,7 @@ snapshots:
       '@types/node': 22.10.1
       '@vitest/coverage-v8': 4.1.6(vitest@4.1.6)
       happy-dom: 20.9.0
+      jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
 
@@ -10998,6 +11396,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   walk-up-path@3.0.1: {}
 
   wcwidth@1.0.1:
@@ -11006,9 +11408,21 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
+  webidl-conversions@8.0.1: {}
+
   webpack-virtual-modules@0.6.2: {}
 
   whatwg-mimetype@3.0.0: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -11112,6 +11526,10 @@ snapshots:
   ws@8.18.2: {}
 
   ws@8.20.1: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
 

--- a/src/components/manguito-theme/lib/directives/index.types.ts
+++ b/src/components/manguito-theme/lib/directives/index.types.ts
@@ -61,4 +61,5 @@ export type TooltipValueType = TooltipValueObjectType | string
 export interface TooltipElementType extends HTMLElement {
   __HandleTooltip: (binding: DirectiveBinding<TooltipValueType>) => void
   __UnmountTooltip: () => void
+  __TooltipId?: string
 }

--- a/src/components/manguito-theme/lib/directives/tooltip.directive.ts
+++ b/src/components/manguito-theme/lib/directives/tooltip.directive.ts
@@ -8,6 +8,8 @@ import type {
   TooltipValueType,
 } from './index.types'
 
+let _tooltipCount = 0
+
 /**
  * Extracts a value from either element attributes or binding value object
  */
@@ -68,11 +70,17 @@ const getDirection = (
  * Mounts the tooltip component to the element
  */
 const mountTooltip = (
-  el: HTMLElement,
+  el: TooltipElementType,
   binding: DirectiveBinding<TooltipValueType>,
 ): void => {
   // add required classes to parent elem
   el.classList.add('relative', 'group', 'overflow-visible')
+
+  if (!el.__TooltipId) {
+    el.__TooltipId = `mcl-tooltip-${++_tooltipCount}`
+  }
+  const tooltipId = el.__TooltipId
+
   const tooltipText = getTooltipText(el, binding)
   const tooltipColor = extractVal<string>(el, binding, 'color', 'color')
   const tooltipTextColor = extractVal<string>(
@@ -92,6 +100,7 @@ const mountTooltip = (
   const tooltipDirection = getDirection(binding)
 
   const vnode = createVNode(tooltip, {
+    id: tooltipId,
     direction: tooltipDirection,
     title: tooltipText,
     color: tooltipColor,
@@ -101,10 +110,13 @@ const mountTooltip = (
   })
 
   render(vnode, el)
+  el.setAttribute('aria-describedby', tooltipId)
 }
 
-const unmountTooltip = (el: HTMLElement): void => {
+const unmountTooltip = (el: TooltipElementType): void => {
   render(null, el)
+  el.removeAttribute('aria-describedby')
+  delete el.__TooltipId
 }
 
 /**

--- a/src/components/manguito-theme/lib/modal/Modal.vue
+++ b/src/components/manguito-theme/lib/modal/Modal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
+import { useFocusTrap } from '@vueuse/integrations/useFocusTrap'
 import { useScrollLock } from '@vueuse/core'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, useId, watch } from 'vue'
 import { observeVisibleAttr } from '../composables'
 import { vClickOutside } from '../directives'
 import { generateClass } from '../theme'
@@ -46,8 +47,16 @@ const emit = defineEmits<{
   (e: 'close', visible: boolean): void
 }>()
 const modalRef = ref<HTMLElement | undefined>()
+const dialogRef = ref<HTMLElement>()
 const toggle = ref<boolean>(props.visible)
 const toggleComplete = ref<boolean>(false)
+const titleId = useId()
+let prevFocus: HTMLElement | null = null
+
+const { activate: activateTrap, deactivate: deactivateTrap } = useFocusTrap(
+  dialogRef,
+  { immediate: false },
+)
 
 const toggleModal = (): void => {
   toggle.value = !toggle.value
@@ -87,12 +96,11 @@ const handleModalWidth = computed(() => {
   return modalWidthClassObj[modalWidth] ?? modalWidthClassObj['small']
 })
 
-/**
- * @TransitionFunctions
- * @summary Handle toggleComplete value after completion of animation
- */
 const onAfterEnter = () => {
   toggleComplete.value = true
+  if (dialogRef.value) {
+    activateTrap()
+  }
 }
 const onAfterLeave = () => {
   toggleComplete.value = false
@@ -113,9 +121,17 @@ watch(
 )
 watch(toggle, (newValue) => {
   if (newValue === true) {
+    if (typeof document !== 'undefined') {
+      prevFocus = document.activeElement as HTMLElement | null
+    }
     emitOpenEvent()
-  } else if (newValue === false && toggleComplete.value === true) {
-    emitCloseEvent()
+  } else if (newValue === false) {
+    deactivateTrap()
+    prevFocus?.focus()
+    prevFocus = null
+    if (toggleComplete.value === true) {
+      emitCloseEvent()
+    }
   }
 })
 onMounted(() => {
@@ -141,6 +157,7 @@ defineExpose<{
       <section
         v-if="toggle"
         @click="closeModal"
+        aria-hidden="true"
         class="fixed inset-0 z-[100] overflow-y-auto bg-opacity-70 backdrop-blur"
         :class="generateClass('BGCOLOR', backdropColor)"
       ></section>
@@ -158,6 +175,10 @@ defineExpose<{
         :class="handleModalWidth"
       >
         <div
+          ref="dialogRef"
+          role="dialog"
+          aria-modal="true"
+          :aria-labelledby="title ? titleId : undefined"
           v-click-outside="closeModal"
           :class="[generateClass('BGCOLOR', color), className]"
           class="relative max-h-[80vh] overflow-y-scroll overscroll-contain md:max-h-[60vh]"
@@ -170,16 +191,18 @@ defineExpose<{
               >
                 <h3
                   v-if="title"
+                  :id="titleId"
                   class="h3-md"
                   :class="generateClass('TEXTCOLOR', titleColor)"
                 >
                   {{ title }}
                 </h3>
-                <button @click="closeModal">
+                <button type="button" aria-label="Close" @click="closeModal">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     height="1em"
                     viewBox="0 0 384 512"
+                    aria-hidden="true"
                     class="h-sm transition-opacity duration-300 ease-in hover:opacity-75 focus:opacity-75"
                     :class="[generateClass('SVGFILL', titleColor)]"
                   >

--- a/src/components/manguito-theme/lib/sidebar/Sidebar.vue
+++ b/src/components/manguito-theme/lib/sidebar/Sidebar.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
+import { useFocusTrap } from '@vueuse/integrations/useFocusTrap'
 import { useScrollLock } from '@vueuse/core'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, useId, watch } from 'vue'
 import { observeVisibleAttr } from '../composables'
 import { vClickOutside } from '../directives'
 import { generateClass } from '../theme'
@@ -44,8 +45,16 @@ const emit = defineEmits<{
 const toggle = ref<boolean>(props.visible)
 const toggleComplete = ref<boolean>(false)
 const sidebarRef = ref<HTMLElement | undefined>()
+const dialogRef = ref<HTMLElement>()
 const headerRef = ref<HTMLElement>()
 const footerRef = ref<HTMLElement>()
+const titleId = useId()
+let prevFocus: HTMLElement | null = null
+
+const { activate: activateTrap, deactivate: deactivateTrap } = useFocusTrap(
+  dialogRef,
+  { immediate: false },
+)
 
 const toggleSidebar = (): void => {
   toggle.value = !toggle.value
@@ -77,18 +86,17 @@ const sidebarClass = computed(() => {
   return props.placement === 'left' ? 'sidebar-left' : 'sidebar-right'
 })
 
-/**
- * @TransitionFunctions
- * Handle toggleComplete value after completion of animation
- */
 const onAfterEnter = () => {
   toggleComplete.value = true
+  if (dialogRef.value) {
+    activateTrap()
+  }
 }
 const onAfterLeave = () => {
   toggleComplete.value = false
 }
 
-// set nutation observer watching `visible` attribute in element
+// set mutation observer watching `visible` attribute in element
 const handleVisibility = (visible: boolean = false) => {
   toggle.value = visible
 }
@@ -103,9 +111,17 @@ watch(
 )
 watch(toggle, (newValue) => {
   if (newValue === true) {
+    if (typeof document !== 'undefined') {
+      prevFocus = document.activeElement as HTMLElement | null
+    }
     emitOpenEvent()
-  } else if (newValue === false && toggleComplete.value === true) {
-    emitCloseEvent()
+  } else if (newValue === false) {
+    deactivateTrap()
+    prevFocus?.focus()
+    prevFocus = null
+    if (toggleComplete.value === true) {
+      emitCloseEvent()
+    }
   }
 })
 onMounted(() => {
@@ -131,6 +147,7 @@ defineExpose<{
       <section
         v-if="toggle"
         @click="closeSidebar"
+        aria-hidden="true"
         class="fixed inset-0 z-[100] overflow-y-auto bg-opacity-70 backdrop-blur"
         :class="generateClass('BGCOLOR', backdropColor)"
       ></section>
@@ -143,6 +160,10 @@ defineExpose<{
     >
       <div
         v-if="toggle"
+        ref="dialogRef"
+        role="dialog"
+        aria-modal="true"
+        :aria-labelledby="title ? titleId : undefined"
         v-click-outside="closeSidebar"
         class="sidebar-body fixed inset-y-0 z-[110] h-full overflow-hidden shadow"
         :class="[placement === 'left' ? 'left-0' : 'right-0']"
@@ -157,11 +178,17 @@ defineExpose<{
                 class="p-xs flex items-center justify-between"
                 :class="generateClass('BGCOLOR', color)"
               >
-                <button @click="closeSidebar" v-if="placement === 'right'">
+                <button
+                  type="button"
+                  aria-label="Close"
+                  @click="closeSidebar"
+                  v-if="placement === 'right'"
+                >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     height="1em"
                     viewBox="0 0 384 512"
+                    aria-hidden="true"
                     class="h-sm transition-opacity duration-300 ease-in hover:opacity-75 focus:opacity-75"
                     :class="[generateClass('SVGFILL', titleColor)]"
                   >
@@ -173,16 +200,23 @@ defineExpose<{
                 </button>
                 <h3
                   v-if="title"
+                  :id="titleId"
                   class="h3-md"
                   :class="generateClass('TEXTCOLOR', titleColor)"
                 >
                   {{ title }}
                 </h3>
-                <button @click="closeSidebar" v-if="placement === 'left'">
+                <button
+                  type="button"
+                  aria-label="Close"
+                  @click="closeSidebar"
+                  v-if="placement === 'left'"
+                >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     height="1em"
                     viewBox="0 0 384 512"
+                    aria-hidden="true"
                     class="h-sm transition-opacity duration-300 ease-in hover:opacity-75 focus:opacity-75"
                     :class="[generateClass('SVGFILL', titleColor)]"
                   >

--- a/src/components/manguito-theme/lib/tooltip/index.ts
+++ b/src/components/manguito-theme/lib/tooltip/index.ts
@@ -1,3 +1,4 @@
+import DOMPurify from 'isomorphic-dompurify'
 import type { PropType } from 'vue'
 import { computed, defineComponent, h } from 'vue'
 import { generateClass } from '../theme'
@@ -13,6 +14,10 @@ const DIRECTION_CLASS_MAP: Record<Direction, string> = {
 export default defineComponent({
   name: 'Tooltip',
   props: {
+    id: {
+      type: String,
+      default: undefined,
+    },
     direction: {
       type: String as PropType<Direction>,
       default: 'right' as Direction,
@@ -40,7 +45,7 @@ export default defineComponent({
   },
   setup(props) {
     const defaultClassList: string =
-      'invisible opacity-0 group-hover:visible group-hover:opacity-100 z-[100] tooltip'
+      'invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus:visible group-focus:opacity-100 z-[100] tooltip'
     const colorClass = computed<string>(() => {
       return [
         generateClass('BGCOLOR', props.color),
@@ -63,9 +68,10 @@ export default defineComponent({
     ])
     return () =>
       h('div', {
+        id: props.id,
         class: classList.value,
         role: 'tooltip',
-        innerHTML: props.title,
+        innerHTML: DOMPurify.sanitize(props.title),
         style: [tooltipWidth.value],
       })
   },

--- a/src/components/manguito-theme/package.json
+++ b/src/components/manguito-theme/package.json
@@ -55,6 +55,9 @@
   },
   "dependencies": {
     "@vueuse/core": "^12.0.0",
+    "@vueuse/integrations": "^14.3.0",
+    "focus-trap": "^8.2.0",
+    "isomorphic-dompurify": "^3.12.0",
     "vue": "^3.5.13"
   },
   "devDependencies": {

--- a/src/components/mcl-collapse/lib/mcl-collapse-a/MclCollapseA.vue
+++ b/src/components/mcl-collapse/lib/mcl-collapse-a/MclCollapseA.vue
@@ -106,18 +106,26 @@ watch(
     ]"
   >
     <div
-      class="py-xs px-sm cursor-pointer transition-[border] duration-500"
+      class="py-xs px-sm transition-[border] duration-500"
       :class="[
         toggle
           ? `border-b ${generateClass('BORDERB', borderColor)} ease-in`
           : 'ease-out',
         generateClass('BGCOLOR', bgColor),
       ]"
-      v-collapse:[collapseId]
     >
       <div class="flex items-center justify-between">
         <h3 :class="getTitleClass(titleSize, titleColor)">
-          {{ title }}
+          <button
+            type="button"
+            :id="`${collapseId}-trigger`"
+            :aria-expanded="toggle"
+            :aria-controls="collapseId"
+            v-collapse:[collapseId]
+            class="w-full cursor-pointer bg-transparent text-left"
+          >
+            {{ title }}
+          </button>
         </h3>
         <div @click.stop class="cursor-default" v-if="slots['tab']">
           <slot name="tab"></slot>
@@ -129,6 +137,8 @@ watch(
         :id="collapseId"
         :visible="visible"
         class-name="py-sm px-xs"
+        role="region"
+        :aria-labelledby="`${collapseId}-trigger`"
         @open="toggleAction"
         @close="toggleAction"
         :accordion="accordion"
@@ -137,6 +147,7 @@ watch(
       </collapse>
     </div>
     <div
+      aria-hidden="true"
       class="px-sm flex cursor-pointer items-center justify-center border-t py-1.5 transition-all duration-500"
       :class="[
         generateClass('BGCOLOR', bgColor),

--- a/src/components/mcl-collapse/lib/mcl-collapse-b/MclCollapseB.vue
+++ b/src/components/mcl-collapse/lib/mcl-collapse-b/MclCollapseB.vue
@@ -108,7 +108,11 @@ watch(
     class="p-2xs w-full overflow-hidden"
     :class="getBorderClass(borderColor, bgColor, rounded, displayShadow)"
   >
-    <div
+    <button
+      type="button"
+      :id="`${collapseId}-trigger`"
+      :aria-expanded="toggle"
+      :aria-controls="collapseId"
       v-collapse:[collapseId]
       class="flex w-full cursor-pointer items-center justify-between px-4 py-2 transition duration-200 ease-in hover:bg-opacity-70"
       :class="[
@@ -116,8 +120,11 @@ watch(
         generateClass('BGCOLOR', btnColor),
       ]"
     >
-      <h3 :class="getTitleClass(titleSize, titleColor)">{{ title }}</h3>
-      <div class="ml-xs md:ml-sm lg:ml-md flex items-center justify-center">
+      <span :class="getTitleClass(titleSize, titleColor)">{{ title }}</span>
+      <div
+        aria-hidden="true"
+        class="ml-xs md:ml-sm lg:ml-md flex items-center justify-center"
+      >
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 448 512"
@@ -133,12 +140,14 @@ watch(
           />
         </svg>
       </div>
-    </div>
+    </button>
     <div class="overflow-hidden">
       <collapse
         :id="collapseId"
         :visible="visible"
         class-name="px-xs pt-xs pb-2xs"
+        role="region"
+        :aria-labelledby="`${collapseId}-trigger`"
         :accordion="accordion"
         @open="toggleAction"
         @close="toggleAction"

--- a/src/components/mcl-forms/lib/mcl-checkbox/MclCheckbox.vue
+++ b/src/components/mcl-forms/lib/mcl-checkbox/MclCheckbox.vue
@@ -141,6 +141,7 @@ const handleCheckboxLayout = computed<string>(() => {
       @change="handleChange"
     />
     <span
+      aria-hidden="true"
       class="relative border inline-block p-3xs hover:bg-opacity-60 peer-checked/input:hover:bg-opacity-60 before:opacity-0 peer-checked/input:before:opacity-100 before:absolute before:top-1/2 before:-translate-y-1/2 before:left-1/2 before:-translate-x-1/2 transition-colors duration-200 ease-linear before:transition-opacity before:duration-200 before:ease-linar"
       :class="[handleCheckboxLayout, handleInputSize]"
       @click="handleCheckboxClick"

--- a/src/components/mcl-forms/lib/mcl-input-file/MclInputFile.vue
+++ b/src/components/mcl-forms/lib/mcl-input-file/MclInputFile.vue
@@ -101,6 +101,8 @@ const getClearButtonClass = computed<string>(() => {
     <!-- browse button -->
     <div class="shrink-0 my-3xs ml-3xs mr-xs">
       <button
+        type="button"
+        :aria-controls="id"
         class="px-xs py-2xs hover:bg-opacity-70 transition-all duration-200 ease-linear max-w-full"
         :class="getButtonClass"
         @click="onButtonClick"
@@ -133,6 +135,7 @@ const getClearButtonClass = computed<string>(() => {
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 384 512"
+          aria-hidden="true"
           class="h-xs"
           :class="generateClass('SVGFILL', buttonTextColor)"
         >

--- a/src/components/mcl-forms/lib/mcl-input-radio/MclInputRadio.vue
+++ b/src/components/mcl-forms/lib/mcl-input-radio/MclInputRadio.vue
@@ -83,6 +83,7 @@ const handleChange = (e: Event) => {
       @change="handleChange"
     />
     <span
+      aria-hidden="true"
       class="rounded-full inline-block relative before:absolute before:rounded-full before:top-1/2 before:left-1/2 before:-translate-x-1/2 before:-translate-y-1/2"
       :class="[getRadioSize, checkedRadioSize, getColorClass]"
       @click="radioClick"

--- a/src/components/mcl-forms/lib/mcl-input-switch/MclInputSwitch.vue
+++ b/src/components/mcl-forms/lib/mcl-input-switch/MclInputSwitch.vue
@@ -104,12 +104,15 @@ const switchClass = computed<string>(() => {
   <div class="switch relative" :style="switchSize" @click="onSwitchClick">
     <input
       :id="id"
-      class="hidden peer/input"
+      class="sr-only peer/input"
       v-model="model"
       ref="inputRef"
       type="checkbox"
+      role="switch"
+      :aria-checked="!!model"
     />
     <span
+      aria-hidden="true"
       class="slider absolute inset-0 cursor-pointer transition-all duration-300 before:absolute before:transition-all before:duration-300"
       :class="switchClass"
     ></span>

--- a/src/components/mcl-forms/lib/mcl-input-text/MclInputText.vue
+++ b/src/components/mcl-forms/lib/mcl-input-text/MclInputText.vue
@@ -18,6 +18,7 @@ const props = withDefaults(
     type?: InputType
     displayShadow?: boolean
     required?: boolean
+    invalid?: boolean
     invalidFeedback?: string
     minLength?: number
     maxLength?: number
@@ -35,6 +36,7 @@ const props = withDefaults(
     type: 'text',
     displayShadow: true,
     required: false,
+    invalid: false,
   }
 )
 
@@ -84,6 +86,8 @@ const inputClass = computed(() => {
       v-model="model"
       :placeholder="placeholder"
       :required="required"
+      :aria-invalid="invalid || undefined"
+      :aria-describedby="invalid ? `${id}-error` : undefined"
       :minlength="minLength"
       :maxlength="maxLength"
       :pattern="pattern"
@@ -94,6 +98,8 @@ const inputClass = computed(() => {
       :rounded="rounded"
     ></input-highlight>
     <div
+      :id="`${id}-error`"
+      role="alert"
       class="peer-valid/validation:hidden peer-invalid/validation:block ml-3xs"
     >
       <slot name="invalid-feedback">

--- a/src/components/mcl-forms/lib/mcl-select/MclSelect.vue
+++ b/src/components/mcl-forms/lib/mcl-select/MclSelect.vue
@@ -21,6 +21,7 @@ const props = withDefaults(
     placeholder?: string
     displayShadow?: boolean
     required?: boolean
+    invalid?: boolean
     options: SelectOptions
     selectColor?: ColorPalette
     invalidFeedback?: string
@@ -38,6 +39,7 @@ const props = withDefaults(
     placeholder: '',
     displayShadow: true,
     required: false,
+    invalid: false,
     invalidFeedback: 'No match.',
   },
 )
@@ -247,6 +249,19 @@ const handleOptionsWidth = computed(() => {
   return { width: `${optionsWidth.value}px` }
 })
 
+const isOptionSelected = (option: string | SelectOptionType): boolean => {
+  if (model.value === null || model.value === '') return false
+  return typeof option === 'string'
+    ? option === model.value
+    : option.value === model.value
+}
+
+const activeDescendant = computed(() =>
+  inputFocus.value && filteredOptions.value.length > 0
+    ? `${props.id}-option-${activeItemIdx.value}`
+    : undefined,
+)
+
 const { floatingStyles } = useFloating(componentRef, dropdownRef, {
   whileElementsMounted: autoUpdate,
   strategy: 'absolute',
@@ -320,6 +335,9 @@ watch(activeItemIdx, () => {
         :placeholder="placeholder"
         aria-autocomplete="list"
         :aria-expanded="inputFocus"
+        :aria-controls="`${id}-listbox`"
+        :aria-activedescendant="activeDescendant"
+        :aria-invalid="invalid || undefined"
         @focus="setInputFocus"
       />
       <div
@@ -370,6 +388,7 @@ watch(activeItemIdx, () => {
       @enter="handleDropdownShown"
     >
       <ul
+        :id="`${id}-listbox`"
         :class="[optionsBlockClass]"
         class="max-h-50 overflow-y-auto border-2"
         :style="{ ...handleOptionsWidth, ...floatingStyles }"
@@ -389,8 +408,10 @@ watch(activeItemIdx, () => {
             <li
               v-for="(option, idx) in filteredOptions"
               :key="idx"
+              :id="`${id}-option-${idx}`"
               class="p-2xs cursor-pointer"
               role="option"
+              :aria-selected="isOptionSelected(option)"
               :class="[
                 activeItemIdx === idx &&
                   generateClass('BGCOLOR', highlightColor),
@@ -407,6 +428,7 @@ watch(activeItemIdx, () => {
           <slot name="no-match">
             <li
               class="p-2xs cursor-pointer"
+              aria-live="polite"
               :class="[generateClass('HVBGCOLOR', selectColor)]"
             >
               <span>{{ invalidFeedback }}</span>

--- a/src/components/mcl-forms/lib/mcl-text-area/MclTextArea.vue
+++ b/src/components/mcl-forms/lib/mcl-text-area/MclTextArea.vue
@@ -17,6 +17,7 @@ const props = withDefaults(
     placeholder?: string
     displayShadow?: boolean
     required?: boolean
+    invalid?: boolean
     rows?: number
   }>(),
   {
@@ -30,6 +31,7 @@ const props = withDefaults(
     placeholder: '',
     displayShadow: true,
     required: false,
+    invalid: false,
     rows: 5,
   }
 )
@@ -79,6 +81,7 @@ const inputClass = computed(() => {
       v-model="model"
       :placeholder="placeholder"
       :required="required"
+      :aria-invalid="invalid || undefined"
       :rows="rows"
     />
     <input-highlight


### PR DESCRIPTION
Add ARIA roles, focus management, and keyboard support across manguito-theme, mcl-collapse, and mcl-forms. Install @vueuse/integrations, focus-trap, and isomorphic-dompurify as new manguito-theme dependencies.

- Modal/Sidebar: role=dialog, aria-modal, aria-labelledby, useFocusTrap, focus store/restore on open/close, aria-label on close buttons
- MclCollapseA/B: button triggers with aria-expanded + aria-controls, role=region on collapse content, bottom chevron aria-hidden
- MclInputText/TextArea/Select: :invalid prop, aria-invalid, aria-describedby, role=alert on error containers
- MclSelect: aria-controls, aria-activedescendant, option ids, aria-selected, aria-live on no-match
- MclInputFile: type=button + aria-controls on browse button
- MclCheckbox/Radio: aria-hidden on visual spans
- MclInputSwitch: hidden -> sr-only, role=switch, aria-checked
- Tooltip: unique id via module counter, aria-describedby on host, group-focus CSS variants for keyboard trigger, DOMPurify sanitization